### PR TITLE
Move phpstan check in code-analizer job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    name: linter-check
+    name: code-anaylizer
     steps:
       - uses: actions/checkout@v1
       - name: Install PHP
@@ -21,8 +21,10 @@ jobs:
           php-version: 8.0
       - name: Install dependencies
         run: composer update --prefer-dist --no-progress
-      - name: Run linter
+      - name: Run PHP CS Fixer
         run: vendor/bin/php-cs-fixer fix -v --config=.php-cs-fixer.dist.php --using-cache=no --dry-run --allow-risky=yes
+      - name: Run PHPStan
+        run: php ./vendor/bin/phpstan
 
   tests:
     # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
@@ -71,5 +73,3 @@ jobs:
         composer require --dev kriswallsmith/buzz nyholm/psr7
         sh scripts/tests.sh
         composer remove --dev kriswallsmith/buzz nyholm/psr7
-    - name: PHPStan
-      run: php ./vendor/bin/phpstan

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 status = [
-    'linter-check',
+    'code-analyzer',
     'integration-tests (PHP 7.3)',
     'integration-tests (PHP 7.4)',
     'integration-tests (PHP 8.0)'


### PR DESCRIPTION
My suggestion of changes 🙂 I would rather the PHPStan run in the same job as PHP CS Fixer